### PR TITLE
feat: improve source listing by excluding more directories #23

### DIFF
--- a/scripts/list_sources.py
+++ b/scripts/list_sources.py
@@ -11,5 +11,7 @@ def list_rs_files(base_path: Path) -> list[Path]:
         path
         for path in base_path.rglob("*.rs")
         if path.is_file()
-        and not any(part in IGNORED_DIRECTORIES for part in path.parts)
+        and not any(
+            part in IGNORED_DIRECTORIES for part in path.relative_to(base_path).parts
+        )
     ]

--- a/scripts/list_sources.py
+++ b/scripts/list_sources.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-IGNORED_DIRECTORIES = {".git", "target", "doc", "package"}
+IGNORED_DIRECTORIES = {".git", "target"}
 
 
 def list_rs_files(base_path: Path) -> list[Path]:
@@ -11,7 +11,5 @@ def list_rs_files(base_path: Path) -> list[Path]:
         path
         for path in base_path.rglob("*.rs")
         if path.is_file()
-        and not any(
-            part in IGNORED_DIRECTORIES for part in path.relative_to(base_path).parts
-        )
+        and path.relative_to(base_path).parts[0] not in IGNORED_DIRECTORIES
     ]

--- a/scripts/list_sources.py
+++ b/scripts/list_sources.py
@@ -3,6 +3,13 @@
 
 from pathlib import Path
 
+IGNORED_DIRECTORIES = {".git", "target", "doc", "package"}
+
 
 def list_rs_files(base_path: Path) -> list[Path]:
-    return [p for p in base_path.rglob("*.rs") if not ".git" in p.parts]
+    return [
+        path
+        for path in base_path.rglob("*.rs")
+        if path.is_file()
+        and not any(part in IGNORED_DIRECTORIES for part in path.parts)
+    ]


### PR DESCRIPTION
Explicitly ignore common build directories like target, doc, and package in addition to .git.

Added path.is_file() check for robustness and replaced inline string check with a set lookup for better maintainability.